### PR TITLE
Fix bug in DataService.removeAction

### DIFF
--- a/src/src/app/shared/services/data.service.ts
+++ b/src/src/app/shared/services/data.service.ts
@@ -23,8 +23,10 @@ export class DataService {
     }
 
     removeAction(id: number) {
-        var index = this.actions.findIndex((a) => a.id == id);
-        this.actions.splice(index, 1);
+        const index = this.actions.findIndex(a => a.id == id);
+        if (index !== -1) {
+            this.actions.splice(index, 1);
+        }
     }
 
     getInput() : ActionInput {


### PR DESCRIPTION
## Summary
- avoid deleting the wrong action when the action id doesn't exist

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68833ae36da083298bed0924b30e75bf